### PR TITLE
Pythonの追加ライブラリのインストール方法の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ cd ./OpenData-Bridge-DataNorm
 ```
 
 ### Pythonでデータ変換＆結合
+追加のライブラリのインストール
+```Python
+pip install -r requirements.txt
+```
+
 - ChatGPTで作成したmapping_rules.jsonをOpenData-Bridge-DataNorm以下に配置
 - 以下のコマンドを実行
 ```Python

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pandas
+chardet


### PR DESCRIPTION
#4 の対応

ローカルで動作確認済み

確認方法
Python環境 : 3.11.5
Win10

```Python
# 仮想環境の作成
$ python -m venv add_python_requirements

# 仮想環境のアクティベート
$ add_python_requirements\Scripts\activate

# インストール前のpip list
$ pip list
Package    Version
---------- -------
pip        23.2.1
setuptools 65.5.0

# 追加ライブラリのインストール
$ pip install -r requirements.txt

# インストール後のpip list
$ pip list
Package         Version
--------------- ------------
chardet         5.2.0
numpy           1.25.2
pandas          2.1.0
pip             23.2.1
python-dateutil 2.8.2
pytz            2023.3.post1
setuptools      65.5.0
six             1.16.0
tzdata          2023.3

# 実行
$ python datanorm.py ./data
```